### PR TITLE
Remove requirement to create 'gdate' alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Backup your Slack chat messages (direct messages, group messages, joined channel
 
 * BASH (`/bin/bash`)
 * jq
-* GNU's date and name it `gdate`
-  - Linux: `alias gdate=date`
+* GNU's date
   - MacOS: `brew install coreutils`
 
 # INSTALLATION

--- a/common.sh
+++ b/common.sh
@@ -9,3 +9,12 @@ function generate-digits() {
   done
   echo $S
 }
+
+if [ "$(uname)" = "Linux" ] &&
+    ! command -v gdate >/dev/null &&
+    command -v date >/dev/null; then
+
+    gdate() {
+        date "$@"
+    }
+fi

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source common.sh
+
 function usage() {
   cat <<EOF
 Usage: $0 [command] [options]
@@ -20,9 +22,6 @@ EOF
 function system_check() {
   uname=$(uname)
   required_commands="curl gdate jq"
-  if [[ "X$uname" == "XLinux" ]]; then
-    echo "You may want to set this alias: 'gdate=date'"
-  fi
   if [[ "X$uname" == "XDarwin" ]]; then
     echo "You may want to brew install: 'coreutils' and 'jq'"
   fi


### PR DESCRIPTION
- In common.sh, define a wrapper function if we're on a Linux system which has a 'date' command but no 'gdate' command
- Source common.sh in run.sh
- Reflect changes in README and test output